### PR TITLE
fix: failed to detect unchanged source files

### DIFF
--- a/src/utils/options-storage.js
+++ b/src/utils/options-storage.js
@@ -6,6 +6,7 @@ const optionsStorage = new OptionsSync({
 		owner: '',
 		repo: '',
 		sourcePath: '',
+		etag: '',
 	},
 	migrations: [
 		OptionsSync.migrations.removeUnused,


### PR DESCRIPTION
We already were using ETags received from the GitHub REST API and caching them in order to prevent uneccessary updates to the bookmarks in case the source (file or directory) was unchanged.

Unfortunately this didn't work because the cached ETag was lost between bookmark syncs. The synchronization happens event-driven inside of a so-called background script. These are unloaded after a period of idle time by the browser, thus losing any state saved.