### PR TITLE
feat: sync bookmarks every hour

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Store bookmarks in a simple JSON structure in your organization's GitHub reposit
 
 ## 🚀 Features
 
-- 🔄 **Automatic Synchronization**: Sync bookmarks every 4 hours and shortly after the browser starts.
+- 🔄 **Automatic Synchronization**: Sync bookmarks every hour and shortly after the browser starts.
 - ✋ **Manual Sync**: Need the latest bookmarks immediately? Trigger a sync manually.
 - 🎯 **Selective Sync**: Syncs only the folders contained in the remote bookmark files without touching others you might have.
 - 📁 **Multi-File Support**: Organize your organizations bookmarks into separate JSON files, for example by project.

--- a/src/entrypoints/background.js
+++ b/src/entrypoints/background.js
@@ -24,7 +24,7 @@ export default defineBackground({
 		jobs.scheduleJob({
 			id: 'sync-bookmarks',
 			type: 'interval',
-			duration: 1000 * 3600 * 4, // Runs every 4 hours
+			duration: 1000 * 3600, // Runs hourly
 			execute() {
 				console.log('Scheduled sync bookmarks job');
 				syncBookmarks();


### PR DESCRIPTION
Given that we do not sync bookmarks if there haven't been any changes in the source and thus will not show a notification to the user, we can now increase the frequency of synchronization attempts.