### PR TITLE
feat: validate bookmark files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
 		"xo": "^0.57.0"
 	},
 	"dependencies": {
+		"@hyperjump/json-schema": "^1.7.2",
+		"@hyperjump/browser": "^1.1.3",
 		"@octokit/plugin-retry": "^6.0.1",
 		"@octokit/rest": "^20.0.2",
 		"@webext-core/job-scheduler": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@hyperjump/browser':
+    specifier: ^1.1.3
+    version: 1.1.3
+  '@hyperjump/json-schema':
+    specifier: ^1.7.2
+    version: 1.7.2(@hyperjump/browser@1.1.3)
   '@octokit/plugin-retry':
     specifier: ^6.0.1
     version: 6.0.1(@octokit/core@5.0.1)
@@ -126,6 +132,7 @@ packages:
   /@commitlint/config-validator@18.6.0:
     resolution: {integrity: sha512-Ptfa865arNozlkjxrYG3qt6wT9AlhNUHeuDyKEZiTL/l0ftncFhK/KN0t/EAMV2tec+0Mwxo0FmhbESj/bI+1g==}
     engines: {node: '>=v18'}
+    requiresBuild: true
     dependencies:
       '@commitlint/types': 18.6.0
       ajv: 8.12.0
@@ -146,6 +153,7 @@ packages:
   /@commitlint/execute-rule@18.4.4:
     resolution: {integrity: sha512-a37Nd3bDQydtg9PCLLWM9ZC+GO7X5i4zJvrggJv5jBhaHsXeQ9ZWdO6ODYR+f0LxBXXNYK3geYXJrCWUCP8JEg==}
     engines: {node: '>=v18'}
+    requiresBuild: true
     dev: true
 
   /@commitlint/format@18.6.0:
@@ -177,6 +185,7 @@ packages:
   /@commitlint/load@18.6.0(@types/node@20.9.0)(typescript@5.3.3):
     resolution: {integrity: sha512-RRssj7TmzT0bowoEKlgwg8uQ7ORXWkw7lYLsZZBMi9aInsJuGNLNWcMxJxRZbwxG3jkCidGUg85WmqJvRjsaDA==}
     engines: {node: '>=v18'}
+    requiresBuild: true
     dependencies:
       '@commitlint/config-validator': 18.6.0
       '@commitlint/execute-rule': 18.4.4
@@ -221,6 +230,7 @@ packages:
   /@commitlint/resolve-extends@18.6.0:
     resolution: {integrity: sha512-k2Xp+Fxeggki2i90vGrbiLDMefPius3zGSTFFlRAPKce/SWLbZtI+uqE9Mne23mHO5lmcSV8z5m6ziiJwGpOcg==}
     engines: {node: '>=v18'}
+    requiresBuild: true
     dependencies:
       '@commitlint/config-validator': 18.6.0
       '@commitlint/types': 18.6.0
@@ -608,6 +618,47 @@ packages:
   /@humanwhocodes/object-schema@2.0.1:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
+
+  /@hyperjump/browser@1.1.3:
+    resolution: {integrity: sha512-H7DtqWbP3YvdbZFTLln3BGPg5gt9B9aUxblIHyFRLMYGoNyq0yJN6LYRb3ZwYcRsxytAOwL6efnEKNFzF91iQQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@hyperjump/json-pointer': 1.0.1
+      '@hyperjump/uri': 1.2.2
+      content-type: 1.0.5
+      just-curry-it: 5.3.0
+    dev: false
+
+  /@hyperjump/json-pointer@1.0.1:
+    resolution: {integrity: sha512-vV2pSc7JCwbKEMzh8kr/ICZdO+UZbA3aZ7N8t7leDi9cduWKa9yoP5LS04LnsbErlPbUNHvWBFlbTaR/o/uf7A==}
+    dependencies:
+      just-curry-it: 5.3.0
+    dev: false
+
+  /@hyperjump/json-schema@1.7.2(@hyperjump/browser@1.1.3):
+    resolution: {integrity: sha512-54Xe9RmpUye9aBZGYPcSAHooFB5ZLSpS5HM4rfFPVhoGi8rC2IdbpS19G50JtwiPy20Bc78dtREawHtFFAJJlA==}
+    peerDependencies:
+      '@hyperjump/browser': ^1.1.0
+    dependencies:
+      '@hyperjump/browser': 1.1.3
+      '@hyperjump/json-pointer': 1.0.1
+      '@hyperjump/pact': 1.3.0
+      '@hyperjump/uri': 1.2.2
+      content-type: 1.0.5
+      fastest-stable-stringify: 2.0.2
+      just-curry-it: 5.3.0
+      uuid: 9.0.1
+    dev: false
+
+  /@hyperjump/pact@1.3.0:
+    resolution: {integrity: sha512-/UIKatOtyZ3kN4A7AQmqZKzg/6es9jKyeWbfrenb2rDb3I9W4ZrVZT8q1zDrI/G+849I6Eq0ybzV1mmEC9zoDg==}
+    dependencies:
+      just-curry-it: 5.3.0
+    dev: false
+
+  /@hyperjump/uri@1.2.2:
+    resolution: {integrity: sha512-Zn8AZb/j54KKUCckmcOzKCSCKpIpMVBc60zYaajD8Dq/1g4UN6TfAFi+uDa5o/6rf+I+5xDZjZpdzwfuhlC0xQ==}
+    dev: false
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -1665,17 +1716,6 @@ packages:
       fill-range: 7.0.1
     dev: true
 
-  /browserslist@4.22.1:
-    resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001561
-      electron-to-chromium: 1.4.580
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.13(browserslist@4.22.1)
-    dev: true
-
   /browserslist@4.22.3:
     resolution: {integrity: sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1829,10 +1869,6 @@ packages:
   /camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
-    dev: true
-
-  /caniuse-lite@1.0.30001561:
-    resolution: {integrity: sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==}
     dev: true
 
   /caniuse-lite@1.0.30001585:
@@ -2129,6 +2165,11 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0}
     dev: true
 
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
@@ -2171,6 +2212,7 @@ packages:
   /cosmiconfig-typescript-loader@5.0.0(@types/node@20.9.0)(cosmiconfig@8.3.6)(typescript@5.3.3):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
+    requiresBuild: true
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=8.2'
@@ -2530,10 +2572,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
-
-  /electron-to-chromium@1.4.580:
-    resolution: {integrity: sha512-T5q3pjQon853xxxHUq3ZP68ZpvJHuSMY2+BZaW3QzjS4HvNuvsMmZ/+lU+nCrftre1jFZ+OSlExynXWBihnXzw==}
     dev: true
 
   /electron-to-chromium@1.4.661:
@@ -3264,6 +3302,10 @@ packages:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
     dev: true
+
+  /fastest-stable-stringify@2.0.2:
+    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
+    dev: false
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -4510,6 +4552,10 @@ packages:
       setimmediate: 1.0.5
     dev: true
 
+  /just-curry-it@5.3.0:
+    resolution: {integrity: sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==}
+    dev: false
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -4643,6 +4689,7 @@ packages:
 
   /lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+    requiresBuild: true
     dev: true
 
   /lodash.kebabcase@4.1.1:
@@ -4659,6 +4706,7 @@ packages:
 
   /lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    requiresBuild: true
     dev: true
 
   /lodash.snakecase@4.1.1:
@@ -4675,6 +4723,7 @@ packages:
 
   /lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+    requiresBuild: true
     dev: true
 
   /lodash.upperfirst@4.3.1:
@@ -5071,10 +5120,6 @@ packages:
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
-    dev: true
-
-  /node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
     dev: true
 
   /node-releases@2.0.14:
@@ -6879,17 +6924,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /update-browserslist-db@1.0.13(browserslist@4.22.1):
-    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.22.1
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: true
-
   /update-browserslist-db@1.0.13(browserslist@4.22.3):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -6939,6 +6973,11 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -7089,7 +7128,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.11.2
       acorn-import-assertions: 1.9.0(acorn@8.11.2)
-      browserslist: 4.22.1
+      browserslist: 4.22.3
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
       es-module-lexer: 1.3.1

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Structure your JSON file for bookmarks as per the schema defined at [https://fre
 
 ```json
 {
+  "$schema": "https://frederikb.github.io/bookmarksync/schemas/bookmarks.1-0-0.schema.json",
   "name": "Bookmarks 1",
   "bookmarks": [
     {
@@ -149,4 +150,5 @@ Distributed under the MIT License. See [`LICENSE`](LICENSE) for more information
 ## 📣 Acknowledgements
 
 - [Octokit](https://github.com/octokit/core.js): Seamless GitHub API integration.
+- [Hyperjump - JSON Schema](https://github.com/hyperjump-io/json-schema): JSON Schema tooling.
 - This project was bootstrapped with [Web Extension Toolkit (wxt.dev)](https://wxt.dev).

--- a/src/entrypoints/background.js
+++ b/src/entrypoints/background.js
@@ -10,6 +10,7 @@ export default defineBackground({
 
 	main() {
 		registerSyncBookmarks(new GitHubBookmarksLoader());
+
 		const syncBookmarks = getSyncBookmarks();
 
 		const jobs = defineJobScheduler();

--- a/src/utils/bookmarks.1-0-0.schema.json
+++ b/src/utils/bookmarks.1-0-0.schema.json
@@ -1,0 +1,157 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://frederikb.github.io/bookmarksync/schemas/bookmarks.1-0-0.schema.json",
+	"title": "Bookmarks",
+	"description": "A named collection of bookmarks as used in a web browser",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"format": "uri",
+			"enum": [
+				"http://example.com/path/to/your/schema.1-0-0.schema.json"
+			],
+			"description": "The URI of this exact JSON schema"
+		},
+		"name": {
+			"type": "string",
+			"description": "Name of the bookmark collection."
+		},
+		"bookmarks": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/bookmarkItem"
+			},
+			"description": "Array of bookmarks, separators or folders."
+		}
+	},
+	"required": [
+		"name",
+		"bookmarks"
+	],
+	"definitions": {
+		"bookmarkItem": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string",
+					"description": "Title of the bookmark or folder. Required unless 'type' is 'separator'."
+				},
+				"url": {
+					"type": "string",
+					"format": "uri",
+					"description": "URL of the bookmark. Only for bookmarks."
+				},
+				"children": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bookmarkItem"
+					},
+					"description": "Nested bookmarks or folders. Only for folders."
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"folder",
+						"bookmark",
+						"separator"
+					],
+					"description": "Type of the item. If absent, inferred from properties."
+				}
+			},
+			"allOf": [
+				{
+					"if": {
+						"required": [
+							"type"
+						],
+						"properties": {
+							"type": {
+								"const": "separator"
+							}
+						}
+					},
+					"then": {
+						"properties": {
+							"title": false,
+							"url": false,
+							"children": false
+						}
+					}
+				},
+				{
+					"if": {
+						"required": [
+							"type"
+						],
+						"properties": {
+							"type": {
+								"const": "bookmark"
+							}
+						}
+					},
+					"then": {
+						"required": [
+							"url",
+							"title"
+						],
+						"properties": {
+							"children": false
+						}
+					}
+				},
+				{
+					"if": {
+						"required": [
+							"type"
+						],
+						"properties": {
+							"type": {
+								"const": "folder"
+							}
+						}
+					},
+					"then": {
+						"required": [
+							"children"
+						],
+						"properties": {
+							"url": false
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"type": false
+						}
+					},
+					"then": {
+						"required": [
+							"title"
+						],
+						"oneOf": [
+							{
+								"required": [
+									"url"
+								],
+								"properties": {
+									"children": false
+								}
+							},
+							{
+								"required": [
+									"children"
+								],
+								"properties": {
+									"url": false
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	}
+}

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -14,4 +14,11 @@ class DataNotFoundError extends Error {
 	}
 }
 
-export {AuthenticationError, DataNotFoundError};
+class BookmarksDataNotValidError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = 'BookmarksDataNotValidError';
+	}
+}
+
+export {AuthenticationError, DataNotFoundError, BookmarksDataNotValidError};

--- a/src/utils/github-bookmarks-loader.js
+++ b/src/utils/github-bookmarks-loader.js
@@ -51,11 +51,10 @@ class GitHubBookmarksLoader {
 				bookmarkFileResponses = [response];
 			}
 
-			const bookmarks = bookmarkFileResponses
-				.flatMap(file => JSON.parse(file.data).bookmarks);
+			const bookmarkFiles = bookmarkFileResponses.map(file => JSON.parse(file.data));
 
 			await optionsStorage.set({etag: response.headers.etag});
-			return bookmarks;
+			return bookmarkFiles;
 		} catch (error) {
 			if (error.status === 304) {
 				console.log('No changes detected in bookmarks - nothing to sync');


### PR DESCRIPTION
The JSON structure supported by this extension was never explictly documented and only explained by examples. Due to upcoming features and knowing how manipulating (deeply) nested JSON by hand is error-prone it makes sense to perform validation before attempting to import the bookmark files.

I defined a JSON schema and additionally published it to a public location. JSON Schema for Bookmarks:
https://frederikb.github.io/bookmarksync/schemas/bookmarks.1-0-0.schema.json In the (rare) case that the schema is updated we need to ensure that the new version is published as well.
The schema is versioned according to [SchemaVer](https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/).

As a side benefit, users may also reference the schema in their bookmark JSON files, via a $schema entry on the root and gain immediate validation in their editor (if supported).

Fixes #29