### PR TITLE
fix: wrong embedded bookmarks JSON schema

### DIFF
--- a/src/utils/bookmarks.1-0-0.schema.json
+++ b/src/utils/bookmarks.1-0-0.schema.json
@@ -10,7 +10,7 @@
 			"type": "string",
 			"format": "uri",
 			"enum": [
-				"http://example.com/path/to/your/schema.1-0-0.schema.json"
+				"https://frederikb.github.io/bookmarksync/schemas/bookmarks.1-0-0.schema.json"
 			],
 			"description": "The URI of this exact JSON schema"
 		},


### PR DESCRIPTION
The embedded JSON schema for bookmarks was invalid and did not match the one published online.
This led to valid bookmark files getting rejected.