### PR TITLE
ci(dependabot): increase open PR limit from 5 to 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 12


### PR DESCRIPTION
Update .github/dependabot.yml to increase Dependabot's open PR limit from 5 to 12, ensuring more critical dependency upgrades are addressed promptly by preventing bottleneck caused by less urgent updates.